### PR TITLE
fix: add error handling for map initialization to prevent app-wide failure

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,11 @@ import { setupControls, updatePreviewStyles } from './src/ui/form.js';
 import { exportToPNG } from './src/core/export.js';
 
 const initialTheme = getSelectedTheme();
-initMap('map-preview', [state.lat, state.lon], state.zoom, initialTheme.tileUrl);
+try {
+	initMap('map-preview', [state.lat, state.lon], state.zoom, initialTheme.tileUrl);
+} catch (err) {
+	console.error('Failed to initialize map:', err);
+}
 
 const syncUI = setupControls();
 

--- a/src/map/map-init.js
+++ b/src/map/map-init.js
@@ -54,7 +54,11 @@ export function initMap(containerId, initialCenter, initialZoom, initialTileUrl)
 		isSyncing = false;
 	});
 
-	initArtisticMap('artistic-map', [initialCenter[1], initialCenter[0]], initialZoom - 1);
+	try {
+		initArtisticMap('artistic-map', [initialCenter[1], initialCenter[0]], initialZoom - 1);
+	} catch (err) {
+		console.error('Failed to initialize artistic map (MapLibre GL):', err);
+	}
 
 	if (state.showRoute) {
 		updateRouteGeometry();


### PR DESCRIPTION
## Problem

When `initArtisticMap()` (MapLibre GL) throws an exception during initialization, the error propagates up through `initMap()` in `main.js` and **prevents `setupControls()` from ever executing**. Since `setupControls()` is responsible for registering all UI event listeners, this causes a complete failure of:

- **City search** (Nominatim geocoding)
- **Theme selection** (standard & artistic)
- **Coordinate inputs**
- **Zoom controls**
- **All other sidebar controls**

This can happen when:
- WebGL is not available or disabled (e.g., headless browsers, some CI environments, GPU blocklist)
- The MapLibre GL container has rendering issues
- GPU driver incompatibilities

### Reproduction

1. Open the app in a browser with WebGL disabled (e.g., Chrome with `--disable-webgl` flag)
2. Try typing in the "Search City" input
3. **Expected**: Search results appear after typing 2+ characters
4. **Actual**: Nothing happens — no network request, no results, no error shown to user

### Root Cause

In `main.js`, the initialization sequence is:

```js
initMap('map-preview', ...);   // If this throws...
const syncUI = setupControls(); // ...this never runs
```

Inside `initMap()`, `initArtisticMap()` creates a `maplibregl.Map` which requires WebGL. If it throws, the entire call stack unwinds with no catch handler.

## Solution

Add `try-catch` blocks around:

1. **`initArtisticMap()` call** in `src/map/map-init.js` — so Leaflet tile rendering still works even if MapLibre fails
2. **`initMap()` call** in `main.js` — so `setupControls()` always executes regardless of map initialization errors

Errors are logged to `console.error()` for debugging.

## Changes

| File | Change |
|------|--------|
| `main.js` | Wrap `initMap()` in try-catch |
| `src/map/map-init.js` | Wrap `initArtisticMap()` in try-catch |

## Testing

- Verified city search works after the fix
- Theme selection, coordinate inputs, and all sidebar controls function normally
- Map tile rendering (Leaflet) continues to work even when MapLibre GL fails
- No behavioral change when both engines initialize successfully